### PR TITLE
adds clap-rs and clog

### DIFF
--- a/helpers/yml/tags.yml
+++ b/helpers/yml/tags.yml
@@ -171,6 +171,8 @@ parser:
  - jesse99/rparse
  - kevinmehall/rust-peg
  - Valloric/nailed
+ - kbknapp/clap-rs
+ - thoughtram/clog
 
 
 hashing:


### PR DESCRIPTION
I put both in parsers because I wasn't sure if you want to break out that category more or not.

`clap` is a command line argument parser

`clog` parses `git` metadata to create a changelog.