### PR TITLE
Add link to CDRS, Apache Cassandra driver

### DIFF
--- a/helpers/yml/tags.yml
+++ b/helpers/yml/tags.yml
@@ -115,6 +115,7 @@ database:
  - blackbeam/rust-mysql-simple
  - mitsuhiko/redis-rs
  - mneumann/rust-redis
+ - AlexPikalov/cdrs
 
 time:
  - lifthrasiir/rust-chrono


### PR DESCRIPTION
Added a link to [CDRS](https://github.com/AlexPikalov/cdrs), pure Rust Cassandra driver. It implements 4-th version of Apache Cassandra protocol specification.